### PR TITLE
Remove margin from body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
-
+body {
+  margin: 0px;
+}
 
 #root {
   height: 100vh;


### PR DESCRIPTION
**Important**

Some reason could add by default this behaviour, this would also work:

```css
body, html {
  padding: 0;
  margin: 0;
  box-sizing: border-box; /* Not supported in IE 6 & IE 7 */
}
```